### PR TITLE
V2/implement match engine capture group extraction

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,6 +109,14 @@
 .match-highlight-5-active { background-color: hsl(var(--match-5) / 0.5); }
 .match-highlight-6-active { background-color: hsl(var(--match-6) / 0.5); }
 
+/* Selected match highlights (ring outline) */
+.match-highlight-1-selected { background-color: hsl(var(--match-1) / 0.4); outline: 2px solid hsl(var(--match-1) / 0.7); outline-offset: -1px; }
+.match-highlight-2-selected { background-color: hsl(var(--match-2) / 0.4); outline: 2px solid hsl(var(--match-2) / 0.7); outline-offset: -1px; }
+.match-highlight-3-selected { background-color: hsl(var(--match-3) / 0.4); outline: 2px solid hsl(var(--match-3) / 0.7); outline-offset: -1px; }
+.match-highlight-4-selected { background-color: hsl(var(--match-4) / 0.4); outline: 2px solid hsl(var(--match-4) / 0.7); outline-offset: -1px; }
+.match-highlight-5-selected { background-color: hsl(var(--match-5) / 0.4); outline: 2px solid hsl(var(--match-5) / 0.7); outline-offset: -1px; }
+.match-highlight-6-selected { background-color: hsl(var(--match-6) / 0.4); outline: 2px solid hsl(var(--match-6) / 0.7); outline-offset: -1px; }
+
 /* Monaco editor custom styles */
 .monaco-editor {
   --vscode-editor-background: hsl(var(--card)) !important;

--- a/src/components/testbench/MatchList.tsx
+++ b/src/components/testbench/MatchList.tsx
@@ -20,7 +20,7 @@ const BADGE_VARIANTS = [
 ] as const;
 
 export function MatchList({ matches, onMatchClick }: MatchListProps) {
-  const { hoverState, setHoveredMatchIndex } = useHoverSync();
+  const { hoverState, setHoveredMatchIndex, setSelectedMatchIndex } = useHoverSync();
 
   if (matches.error) {
     return (
@@ -48,9 +48,15 @@ export function MatchList({ matches, onMatchClick }: MatchListProps) {
           match={match}
           index={index}
           isHovered={hoverState.hoveredMatchIndex === index}
+          isSelected={hoverState.selectedMatchIndex === index}
           onMouseEnter={() => setHoveredMatchIndex(index)}
           onMouseLeave={() => setHoveredMatchIndex(null)}
-          onClick={() => onMatchClick?.(index, match.full.start, match.full.end)}
+          onClick={() => {
+            setSelectedMatchIndex(
+              hoverState.selectedMatchIndex === index ? null : index
+            );
+            onMatchClick?.(index, match.full.start, match.full.end);
+          }}
         />
       ))}
       {matches.truncated && (
@@ -66,6 +72,7 @@ interface MatchItemProps {
   match: Match;
   index: number;
   isHovered: boolean;
+  isSelected: boolean;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
   onClick?: () => void;
@@ -75,6 +82,7 @@ function MatchItem({
   match,
   index,
   isHovered,
+  isSelected,
   onMouseEnter,
   onMouseLeave,
   onClick,
@@ -87,8 +95,12 @@ function MatchItem({
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
       className={cn(
-        "p-2 rounded-md border border-border transition-colors duration-150",
-        isHovered ? "bg-accent" : "bg-card hover:bg-accent/50",
+        "p-2 rounded-md border transition-colors duration-150",
+        isSelected
+          ? "border-primary ring-2 ring-primary/50 bg-accent"
+          : isHovered
+            ? "border-border bg-accent"
+            : "border-border bg-card hover:bg-accent/50",
         onClick && "cursor-pointer"
       )}
       onMouseEnter={onMouseEnter}

--- a/src/components/testbench/MatchOverlay.tsx
+++ b/src/components/testbench/MatchOverlay.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback } from "react";
+import { useHoverSync } from "@/hooks/useHoverSync";
+import { cn } from "@/lib/utils";
+
+const HIGHLIGHT_CLASSES = [
+  "match-highlight-1",
+  "match-highlight-2",
+  "match-highlight-3",
+  "match-highlight-4",
+  "match-highlight-5",
+  "match-highlight-6",
+];
+
+export interface HighlightSegment {
+  text: string;
+  isMatch: boolean;
+  matchIndex: number;
+}
+
+interface MatchOverlayProps {
+  segments: HighlightSegment[];
+}
+
+export function MatchOverlay({ segments }: MatchOverlayProps) {
+  const { hoverState, setHoveredMatchIndex, setSelectedMatchIndex } =
+    useHoverSync();
+
+  const handleMouseEnter = useCallback(
+    (matchIndex: number) => {
+      setHoveredMatchIndex(matchIndex);
+    },
+    [setHoveredMatchIndex]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setHoveredMatchIndex(null);
+  }, [setHoveredMatchIndex]);
+
+  const handleClick = useCallback(
+    (matchIndex: number) => {
+      setSelectedMatchIndex(
+        hoverState.selectedMatchIndex === matchIndex ? null : matchIndex
+      );
+    },
+    [hoverState.selectedMatchIndex, setSelectedMatchIndex]
+  );
+
+  return (
+    <div
+      className="absolute inset-0 p-4 pointer-events-none font-mono text-sm whitespace-pre-wrap break-words overflow-hidden"
+      aria-hidden="true"
+    >
+      {segments.map((segment, index) => {
+        if (!segment.isMatch) {
+          return <span key={index}>{segment.text}</span>;
+        }
+
+        const colorIndex = segment.matchIndex % HIGHLIGHT_CLASSES.length;
+        const isHovered =
+          hoverState.hoveredMatchIndex === segment.matchIndex;
+        const isSelected =
+          hoverState.selectedMatchIndex === segment.matchIndex;
+
+        return (
+          <span
+            key={index}
+            className={cn(
+              HIGHLIGHT_CLASSES[colorIndex],
+              isHovered && `${HIGHLIGHT_CLASSES[colorIndex]}-active`,
+              isSelected && `${HIGHLIGHT_CLASSES[colorIndex]}-selected`,
+              "rounded-sm transition-colors duration-150 pointer-events-auto cursor-pointer"
+            )}
+            onMouseEnter={() => handleMouseEnter(segment.matchIndex)}
+            onMouseLeave={handleMouseLeave}
+            onClick={() => handleClick(segment.matchIndex)}
+          >
+            {segment.text}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/testbench/TestTextEditor.tsx
+++ b/src/components/testbench/TestTextEditor.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useCallback, useRef, useImperativeHandle, forwardRef } from "react";
+import { useMemo, useRef, useImperativeHandle, forwardRef } from "react";
 import { MatchResult } from "@/types";
-import { useHoverSync } from "@/hooks/useHoverSync";
+import { MatchOverlay } from "./MatchOverlay";
 import { cn } from "@/lib/utils";
 
 export interface TestTextEditorRef {
@@ -17,18 +17,8 @@ interface TestTextEditorProps {
   flags: string;
 }
 
-const HIGHLIGHT_CLASSES = [
-  "match-highlight-1",
-  "match-highlight-2",
-  "match-highlight-3",
-  "match-highlight-4",
-  "match-highlight-5",
-  "match-highlight-6",
-];
-
 export const TestTextEditor = forwardRef<TestTextEditorRef, TestTextEditorProps>(
   function TestTextEditor({ value, onChange, matches, pattern, flags: _flags }, ref) {
-  const { hoverState, setHoveredMatchIndex } = useHoverSync();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useImperativeHandle(ref, () => ({
@@ -92,17 +82,6 @@ export const TestTextEditor = forwardRef<TestTextEditorRef, TestTextEditorProps>
     return segments;
   }, [value, matches.spans]);
 
-  const handleMouseEnter = useCallback(
-    (matchIndex: number) => {
-      setHoveredMatchIndex(matchIndex);
-    },
-    [setHoveredMatchIndex]
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    setHoveredMatchIndex(null);
-  }, [setHoveredMatchIndex]);
-
   return (
     <div className="relative h-full">
       {/* Actual textarea for editing */}
@@ -123,34 +102,7 @@ export const TestTextEditor = forwardRef<TestTextEditorRef, TestTextEditorProps>
 
       {/* Highlight overlay - positioned behind the text */}
       {matches.spans.length > 0 && (
-        <div
-          className="absolute inset-0 p-4 pointer-events-none font-mono text-sm whitespace-pre-wrap break-words overflow-hidden"
-          aria-hidden="true"
-        >
-          {highlightedSegments.map((segment, index) => {
-            if (!segment.isMatch) {
-              return <span key={index}>{segment.text}</span>;
-            }
-
-            const colorIndex = segment.matchIndex % HIGHLIGHT_CLASSES.length;
-            const isHovered = hoverState.hoveredMatchIndex === segment.matchIndex;
-            
-            return (
-              <span
-                key={index}
-                className={cn(
-                  HIGHLIGHT_CLASSES[colorIndex],
-                  isHovered && `${HIGHLIGHT_CLASSES[colorIndex]}-active`,
-                  "rounded-sm transition-colors duration-150 pointer-events-auto cursor-pointer"
-                )}
-                onMouseEnter={() => handleMouseEnter(segment.matchIndex)}
-                onMouseLeave={handleMouseLeave}
-              >
-                {segment.text}
-              </span>
-            );
-          })}
-        </div>
+        <MatchOverlay segments={highlightedSegments} />
       )}
 
       {/* Empty state */}

--- a/src/components/testbench/__tests__/MatchList.test.tsx
+++ b/src/components/testbench/__tests__/MatchList.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MatchList } from "../MatchList";
+import { MatchResult } from "@/types";
+import { HoverState } from "@/lib/stores/hoverStore";
+
+const defaultHoverState: HoverState = {
+  hoveredRange: null,
+  hoveredStepId: null,
+  hoveredMatchIndex: null,
+  selectedMatchIndex: null,
+  lockedStepId: null,
+};
+
+const mockSetHoveredMatchIndex = vi.fn();
+const mockSetSelectedMatchIndex = vi.fn();
+
+let currentHoverState = { ...defaultHoverState };
+
+vi.mock("@/hooks/useHoverSync", () => ({
+  useHoverSync: () => ({
+    hoverState: currentHoverState,
+    setHoveredRange: vi.fn(),
+    setHoveredStepId: vi.fn(),
+    setHoveredMatchIndex: mockSetHoveredMatchIndex,
+    setSelectedMatchIndex: mockSetSelectedMatchIndex,
+    toggleLockedStep: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  cleanup();
+  currentHoverState = { ...defaultHoverState };
+  mockSetHoveredMatchIndex.mockReset();
+  mockSetSelectedMatchIndex.mockReset();
+});
+
+const emptyResult: MatchResult = {
+  matches: [],
+  spans: [],
+  truncated: false,
+  totalCount: 0,
+};
+
+const errorResult: MatchResult = {
+  ...emptyResult,
+  error: "Matching timed out",
+};
+
+const singleMatch: MatchResult = {
+  matches: [
+    {
+      index: 0,
+      full: { groupIndex: 0, start: 0, end: 3, text: "abc" },
+      groups: [],
+    },
+  ],
+  spans: [{ start: 0, end: 3, matchIndex: 0 }],
+  truncated: false,
+  totalCount: 1,
+};
+
+const matchWithGroups: MatchResult = {
+  matches: [
+    {
+      index: 0,
+      full: { groupIndex: 0, start: 0, end: 7, text: "123-abc" },
+      groups: [
+        { groupIndex: 1, start: 0, end: 3, text: "123" },
+        { groupIndex: 2, start: 4, end: 7, text: "abc" },
+      ],
+    },
+  ],
+  spans: [{ start: 0, end: 7, matchIndex: 0 }],
+  truncated: false,
+  totalCount: 1,
+};
+
+const matchWithNamedGroups: MatchResult = {
+  matches: [
+    {
+      index: 0,
+      full: { groupIndex: 0, start: 0, end: 7, text: "2024-01" },
+      groups: [
+        { groupIndex: 1, start: 0, end: 4, text: "2024" },
+        { groupIndex: 2, start: 5, end: 7, text: "01" },
+      ],
+      namedGroups: {
+        year: { groupIndex: -1, name: "year", start: 0, end: 4, text: "2024" },
+        month: { groupIndex: -1, name: "month", start: 5, end: 7, text: "01" },
+      },
+    },
+  ],
+  spans: [{ start: 0, end: 7, matchIndex: 0 }],
+  truncated: false,
+  totalCount: 1,
+};
+
+const truncatedResult: MatchResult = {
+  matches: [
+    {
+      index: 0,
+      full: { groupIndex: 0, start: 0, end: 1, text: "a" },
+      groups: [],
+    },
+  ],
+  spans: [{ start: 0, end: 1, matchIndex: 0 }],
+  truncated: true,
+  totalCount: 1500,
+};
+
+describe("MatchList", () => {
+  describe("empty and error states", () => {
+    it("shows empty state message when no matches", () => {
+      render(<MatchList matches={emptyResult} />);
+      expect(screen.getByText("No matches to display")).toBeInTheDocument();
+    });
+
+    it("shows error message", () => {
+      render(<MatchList matches={errorResult} />);
+      expect(screen.getByText("Matching timed out")).toBeInTheDocument();
+    });
+  });
+
+  describe("match rendering", () => {
+    it("renders a match item with badge and position", () => {
+      render(<MatchList matches={singleMatch} />);
+      expect(screen.getByText("Match 1")).toBeInTheDocument();
+      expect(screen.getByText(/pos 0–3/)).toBeInTheDocument();
+    });
+
+    it("renders numbered groups", () => {
+      render(<MatchList matches={matchWithGroups} />);
+      expect(screen.getByText(/Group 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Group 2/)).toBeInTheDocument();
+    });
+
+    it("renders named groups section", () => {
+      render(<MatchList matches={matchWithNamedGroups} />);
+      expect(screen.getByText("Named groups:")).toBeInTheDocument();
+      expect(screen.getByText("year:")).toBeInTheDocument();
+      expect(screen.getByText("month:")).toBeInTheDocument();
+    });
+
+    it("shows truncation notice", () => {
+      render(<MatchList matches={truncatedResult} />);
+      expect(
+        screen.getByText(/Showing first 1 of 1500 matches/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls onMatchClick with correct args", () => {
+      const onClick = vi.fn();
+      render(<MatchList matches={singleMatch} onMatchClick={onClick} />);
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+      expect(onClick).toHaveBeenCalledWith(0, 0, 3);
+    });
+
+    it("fires setSelectedMatchIndex on click", () => {
+      const onClick = vi.fn();
+      render(<MatchList matches={singleMatch} onMatchClick={onClick} />);
+      fireEvent.click(screen.getByRole("button"));
+      expect(mockSetSelectedMatchIndex).toHaveBeenCalledWith(0);
+    });
+
+    it("toggles selection off when clicking already-selected match", () => {
+      currentHoverState = { ...defaultHoverState, selectedMatchIndex: 0 };
+      const onClick = vi.fn();
+      render(<MatchList matches={singleMatch} onMatchClick={onClick} />);
+      fireEvent.click(screen.getByRole("button"));
+      expect(mockSetSelectedMatchIndex).toHaveBeenCalledWith(null);
+    });
+
+    it("fires setHoveredMatchIndex on mouse enter/leave", () => {
+      render(<MatchList matches={singleMatch} />);
+      const item = screen.getByRole("button");
+      fireEvent.mouseEnter(item);
+      expect(mockSetHoveredMatchIndex).toHaveBeenCalledWith(0);
+      fireEvent.mouseLeave(item);
+      expect(mockSetHoveredMatchIndex).toHaveBeenCalledWith(null);
+    });
+
+    it("supports keyboard activation with Enter", () => {
+      const onClick = vi.fn();
+      render(<MatchList matches={singleMatch} onMatchClick={onClick} />);
+      const button = screen.getByRole("button");
+      fireEvent.keyDown(button, { key: "Enter" });
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+
+  describe("styling", () => {
+    it("applies selected styling when match is selected", () => {
+      currentHoverState = { ...defaultHoverState, selectedMatchIndex: 0 };
+      render(<MatchList matches={singleMatch} />);
+      const item = screen.getByRole("button");
+      expect(item.className).toContain("ring-2");
+      expect(item.className).toContain("border-primary");
+    });
+
+    it("applies hover styling when match is hovered", () => {
+      currentHoverState = { ...defaultHoverState, hoveredMatchIndex: 0 };
+      render(<MatchList matches={singleMatch} />);
+      const item = screen.getByRole("button");
+      expect(item.className).toContain("bg-accent");
+    });
+
+    it("applies default styling when neither hovered nor selected", () => {
+      render(<MatchList matches={singleMatch} />);
+      const item = screen.getByRole("button");
+      expect(item.className).toContain("bg-card");
+      expect(item.className).not.toContain("ring-2");
+    });
+  });
+});

--- a/src/components/testbench/__tests__/MatchOverlay.test.tsx
+++ b/src/components/testbench/__tests__/MatchOverlay.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MatchOverlay, HighlightSegment } from "../MatchOverlay";
+import { HoverState } from "@/lib/stores/hoverStore";
+
+const defaultHoverState: HoverState = {
+  hoveredRange: null,
+  hoveredStepId: null,
+  hoveredMatchIndex: null,
+  selectedMatchIndex: null,
+  lockedStepId: null,
+};
+
+const mockSetHoveredMatchIndex = vi.fn();
+const mockSetSelectedMatchIndex = vi.fn();
+
+let currentHoverState = { ...defaultHoverState };
+
+vi.mock("@/hooks/useHoverSync", () => ({
+  useHoverSync: () => ({
+    hoverState: currentHoverState,
+    setHoveredRange: vi.fn(),
+    setHoveredStepId: vi.fn(),
+    setHoveredMatchIndex: mockSetHoveredMatchIndex,
+    setSelectedMatchIndex: mockSetSelectedMatchIndex,
+    toggleLockedStep: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  cleanup();
+  currentHoverState = { ...defaultHoverState };
+  mockSetHoveredMatchIndex.mockReset();
+  mockSetSelectedMatchIndex.mockReset();
+});
+
+const plainSegments: HighlightSegment[] = [
+  { text: "hello world", isMatch: false, matchIndex: -1 },
+];
+
+const matchSegments: HighlightSegment[] = [
+  { text: "abc ", isMatch: false, matchIndex: -1 },
+  { text: "123", isMatch: true, matchIndex: 0 },
+  { text: " def ", isMatch: false, matchIndex: -1 },
+  { text: "456", isMatch: true, matchIndex: 1 },
+];
+
+describe("MatchOverlay", () => {
+  it("renders plain text for non-match segments", () => {
+    render(<MatchOverlay segments={plainSegments} />);
+    expect(screen.getByText("hello world")).toBeInTheDocument();
+  });
+
+  it("renders all segments including matches", () => {
+    const { container } = render(<MatchOverlay segments={matchSegments} />);
+    const spans = container.querySelectorAll("span");
+    // 4 segments: "abc ", "123", " def ", "456"
+    expect(spans).toHaveLength(4);
+    expect(spans[0].textContent).toBe("abc ");
+    expect(spans[1].textContent).toBe("123");
+    expect(spans[2].textContent).toBe(" def ");
+    expect(spans[3].textContent).toBe("456");
+  });
+
+  it("applies highlight class to match segments", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    const matchSpan = screen.getByText("123");
+    expect(matchSpan.className).toContain("match-highlight-1");
+  });
+
+  it("applies different highlight classes for different match indices", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    const first = screen.getByText("123");
+    const second = screen.getByText("456");
+    expect(first.className).toContain("match-highlight-1");
+    expect(second.className).toContain("match-highlight-2");
+  });
+
+  it("applies active class when match is hovered", () => {
+    currentHoverState = { ...defaultHoverState, hoveredMatchIndex: 0 };
+    render(<MatchOverlay segments={matchSegments} />);
+    const matchSpan = screen.getByText("123");
+    expect(matchSpan.className).toContain("match-highlight-1-active");
+  });
+
+  it("does not apply active class to non-hovered matches", () => {
+    currentHoverState = { ...defaultHoverState, hoveredMatchIndex: 0 };
+    render(<MatchOverlay segments={matchSegments} />);
+    const other = screen.getByText("456");
+    expect(other.className).not.toContain("-active");
+  });
+
+  it("applies selected class when match is selected", () => {
+    currentHoverState = { ...defaultHoverState, selectedMatchIndex: 0 };
+    render(<MatchOverlay segments={matchSegments} />);
+    const matchSpan = screen.getByText("123");
+    expect(matchSpan.className).toContain("match-highlight-1-selected");
+  });
+
+  it("fires setHoveredMatchIndex on mouse enter", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    fireEvent.mouseEnter(screen.getByText("123"));
+    expect(mockSetHoveredMatchIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("fires setHoveredMatchIndex(null) on mouse leave", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    fireEvent.mouseLeave(screen.getByText("123"));
+    expect(mockSetHoveredMatchIndex).toHaveBeenCalledWith(null);
+  });
+
+  it("fires setSelectedMatchIndex on click", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    fireEvent.click(screen.getByText("123"));
+    expect(mockSetSelectedMatchIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("toggles off selection when clicking already-selected match", () => {
+    currentHoverState = { ...defaultHoverState, selectedMatchIndex: 0 };
+    render(<MatchOverlay segments={matchSegments} />);
+    fireEvent.click(screen.getByText("123"));
+    expect(mockSetSelectedMatchIndex).toHaveBeenCalledWith(null);
+  });
+
+  it("has aria-hidden on the overlay container", () => {
+    const { container } = render(<MatchOverlay segments={matchSegments} />);
+    const overlay = container.firstElementChild;
+    expect(overlay?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("match spans have pointer-events-auto for interactivity", () => {
+    render(<MatchOverlay segments={matchSegments} />);
+    const matchSpan = screen.getByText("123");
+    expect(matchSpan.className).toContain("pointer-events-auto");
+  });
+});

--- a/src/hooks/__tests__/useHoverSync.test.tsx
+++ b/src/hooks/__tests__/useHoverSync.test.tsx
@@ -15,6 +15,7 @@ describe("useHoverSync", () => {
       hoveredRange: null,
       hoveredStepId: null,
       hoveredMatchIndex: null,
+      selectedMatchIndex: null,
       lockedStepId: null,
     });
   });
@@ -37,6 +38,15 @@ describe("useHoverSync", () => {
     expect(result.current.hoverState.hoveredMatchIndex).toBe(2);
   });
 
+  it("setSelectedMatchIndex updates state", () => {
+    const { result } = renderHook(() => useHoverSync());
+    act(() => result.current.setSelectedMatchIndex(1));
+    expect(result.current.hoverState.selectedMatchIndex).toBe(1);
+
+    act(() => result.current.setSelectedMatchIndex(null));
+    expect(result.current.hoverState.selectedMatchIndex).toBeNull();
+  });
+
   it("toggleLockedStep toggles step lock", () => {
     const { result } = renderHook(() => useHoverSync());
     act(() => result.current.toggleLockedStep("step-1"));
@@ -53,6 +63,7 @@ describe("useHoverSync", () => {
       result.current.setHoveredRange({ start: 0, end: 5 });
       result.current.setHoveredStepId("step-1");
       result.current.setHoveredMatchIndex(2);
+      result.current.setSelectedMatchIndex(3);
       result.current.toggleLockedStep("step-3");
     });
 
@@ -62,6 +73,7 @@ describe("useHoverSync", () => {
       hoveredRange: null,
       hoveredStepId: null,
       hoveredMatchIndex: null,
+      selectedMatchIndex: null,
       lockedStepId: null,
     });
   });

--- a/src/hooks/__tests__/useRegexMatches.test.tsx
+++ b/src/hooks/__tests__/useRegexMatches.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useRegexMatches, FIXTURE_TIMEOUT_MS } from "../useRegexMatches";
+import { REGEX_CONFIG, MatchResult } from "@/types";
+
+const mockMatchResult: MatchResult = {
+  matches: [
+    {
+      index: 0,
+      full: { groupIndex: 0, start: 0, end: 3, text: "123" },
+      groups: [],
+    },
+  ],
+  spans: [{ start: 0, end: 3, matchIndex: 0 }],
+  truncated: false,
+  totalCount: 1,
+};
+
+const emptyResult: MatchResult = {
+  matches: [],
+  spans: [],
+  truncated: false,
+  totalCount: 0,
+};
+
+const mockMatchWithTimeout = vi.fn<
+  (
+    pattern: string,
+    flags: string,
+    text: string,
+    timeoutMs?: number
+  ) => Promise<MatchResult>
+>();
+
+vi.mock("@/lib/regex/matchWithTimeout", () => ({
+  matchWithTimeout: (...args: unknown[]) =>
+    mockMatchWithTimeout(...(args as [string, string, string, number?])),
+}));
+
+beforeEach(() => {
+  mockMatchWithTimeout.mockReset();
+  mockMatchWithTimeout.mockResolvedValue(mockMatchResult);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useRegexMatches", () => {
+  it("returns empty result when parseOk is false", async () => {
+    const { result } = renderHook(() =>
+      useRegexMatches("\\d+", "g", "123", false, 0)
+    );
+
+    // Even with 0 debounce, should not call because parseOk is false
+    await waitFor(() => {
+      expect(result.current).toEqual(emptyResult);
+    });
+    expect(mockMatchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns empty result when pattern is empty", async () => {
+    const { result } = renderHook(() =>
+      useRegexMatches("", "g", "123", true, 0)
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(emptyResult);
+    });
+    expect(mockMatchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("calls matchWithTimeout with correct args", async () => {
+    renderHook(() =>
+      useRegexMatches("\\d+", "g", "abc123", true, 0)
+    );
+
+    await waitFor(() => {
+      expect(mockMatchWithTimeout).toHaveBeenCalledWith(
+        "\\d+",
+        "g",
+        "abc123",
+        REGEX_CONFIG.MATCH_TIMEOUT_MS
+      );
+    });
+  });
+
+  it("returns match result once resolved", async () => {
+    const { result } = renderHook(() =>
+      useRegexMatches("\\d+", "g", "123", true, 0)
+    );
+
+    await waitFor(() => {
+      expect(result.current.totalCount).toBe(1);
+      expect(result.current.matches[0].full.text).toBe("123");
+    });
+  });
+
+  it("passes fixtureTimeoutMs when provided", async () => {
+    renderHook(() =>
+      useRegexMatches("\\d+", "g", "123", true, 0, FIXTURE_TIMEOUT_MS)
+    );
+
+    await waitFor(() => {
+      expect(mockMatchWithTimeout).toHaveBeenCalledWith(
+        "\\d+",
+        "g",
+        "123",
+        FIXTURE_TIMEOUT_MS
+      );
+    });
+  });
+
+  it("resets to empty when parseOk changes to false", async () => {
+    const { result, rerender } = renderHook(
+      ({ parseOk }: { parseOk: boolean }) =>
+        useRegexMatches("\\d+", "g", "123", parseOk, 0),
+      { initialProps: { parseOk: true } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.totalCount).toBe(1);
+    });
+
+    rerender({ parseOk: false });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(emptyResult);
+    });
+  });
+
+  it("cancels stale results when inputs change", async () => {
+    let resolveFirst!: (value: MatchResult) => void;
+    let resolveSecond!: (value: MatchResult) => void;
+
+    const firstResult: MatchResult = {
+      ...emptyResult,
+      totalCount: 1,
+      matches: [
+        {
+          index: 0,
+          full: { groupIndex: 0, start: 0, end: 1, text: "a" },
+          groups: [],
+        },
+      ],
+    };
+    const secondResult: MatchResult = {
+      ...emptyResult,
+      totalCount: 2,
+      matches: [
+        {
+          index: 0,
+          full: { groupIndex: 0, start: 0, end: 1, text: "b" },
+          groups: [],
+        },
+        {
+          index: 1,
+          full: { groupIndex: 0, start: 1, end: 2, text: "b" },
+          groups: [],
+        },
+      ],
+    };
+
+    mockMatchWithTimeout
+      .mockImplementationOnce(
+        () => new Promise<MatchResult>((r) => { resolveFirst = r; })
+      )
+      .mockImplementationOnce(
+        () => new Promise<MatchResult>((r) => { resolveSecond = r; })
+      );
+
+    const { result, rerender } = renderHook(
+      ({ pattern }: { pattern: string }) =>
+        useRegexMatches(pattern, "g", "test", true, 0),
+      { initialProps: { pattern: "a" } }
+    );
+
+    // Wait for first call
+    await waitFor(() => {
+      expect(mockMatchWithTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    // Change pattern — triggers cleanup (cancelled=true) and new effect
+    rerender({ pattern: "b" });
+
+    await waitFor(() => {
+      expect(mockMatchWithTimeout).toHaveBeenCalledTimes(2);
+    });
+
+    // Resolve first (stale) — should be ignored due to cancelled flag
+    await act(async () => { resolveFirst(firstResult); });
+
+    // Resolve second (current)
+    await act(async () => { resolveSecond(secondResult); });
+
+    await waitFor(() => {
+      // Should have the second result, not the first
+      expect(result.current.totalCount).toBe(2);
+    });
+  });
+});

--- a/src/hooks/useHoverSync.tsx
+++ b/src/hooks/useHoverSync.tsx
@@ -8,6 +8,7 @@ import {
   setHoveredRange,
   setHoveredStepId,
   setHoveredMatchIndex,
+  setSelectedMatchIndex,
   toggleLockedStep,
   clearAll,
 } from "@/lib/stores/hoverStore";
@@ -20,6 +21,7 @@ export interface HoverSyncContextValue {
   setHoveredRange: (range: Range | null) => void;
   setHoveredStepId: (stepId: string | null) => void;
   setHoveredMatchIndex: (index: number | null) => void;
+  setSelectedMatchIndex: (index: number | null) => void;
   toggleLockedStep: (stepId: string) => void;
   clearAll: () => void;
 }
@@ -37,6 +39,7 @@ export function useHoverSync(): HoverSyncContextValue {
       setHoveredRange,
       setHoveredStepId,
       setHoveredMatchIndex,
+      setSelectedMatchIndex,
       toggleLockedStep,
       clearAll,
     }),

--- a/src/lib/regex/match.test.ts
+++ b/src/lib/regex/match.test.ts
@@ -1,17 +1,260 @@
 import { describe, it, expect } from "vitest";
-import { computeMatches } from "./match";
+import { computeMatches, getMatchColorClass, computeSingleExecWithLastIndex } from "./match";
+import { REGEX_CONFIG } from "@/types";
 
 describe("computeMatches", () => {
-  it("returns empty when pattern or text is empty", () => {
-    expect(computeMatches("", "g", "foo").totalCount).toBe(0);
-    expect(computeMatches("\\d+", "g", "").totalCount).toBe(0);
+  describe("empty / early exit", () => {
+    it("returns empty when pattern is empty", () => {
+      const r = computeMatches("", "g", "foo");
+      expect(r.totalCount).toBe(0);
+      expect(r.matches).toHaveLength(0);
+      expect(r.spans).toHaveLength(0);
+    });
+
+    it("returns empty when text is empty", () => {
+      const r = computeMatches("\\d+", "g", "");
+      expect(r.totalCount).toBe(0);
+    });
+
+    it("returns empty when both are empty", () => {
+      const r = computeMatches("", "", "");
+      expect(r.totalCount).toBe(0);
+    });
   });
 
-  it("finds digit runs with global flag implied", () => {
-    const r = computeMatches("\\d+", "", "a12b3");
-    expect(r.totalCount).toBe(2);
-    expect(r.matches).toHaveLength(2);
-    expect(r.matches[0]?.full.text).toBe("12");
-    expect(r.matches[1]?.full.text).toBe("3");
+  describe("global and non-global matching", () => {
+    it("finds all matches with explicit global flag", () => {
+      const r = computeMatches("\\d+", "g", "a12b3c456");
+      expect(r.totalCount).toBe(3);
+      expect(r.matches.map((m) => m.full.text)).toEqual(["12", "3", "456"]);
+    });
+
+    it("forces global flag when not provided", () => {
+      const r = computeMatches("\\d+", "", "a12b3");
+      expect(r.totalCount).toBe(2);
+      expect(r.matches).toHaveLength(2);
+      expect(r.matches[0]?.full.text).toBe("12");
+      expect(r.matches[1]?.full.text).toBe("3");
+    });
+
+    it("preserves other flags alongside forced global", () => {
+      const r = computeMatches("hello", "i", "Hello HELLO hello");
+      expect(r.totalCount).toBe(3);
+    });
+
+    it("returns no matches when pattern does not match", () => {
+      const r = computeMatches("xyz", "g", "abc def");
+      expect(r.totalCount).toBe(0);
+      expect(r.matches).toHaveLength(0);
+    });
+  });
+
+  describe("span positions", () => {
+    it("reports correct start and end for each match", () => {
+      const r = computeMatches("\\w+", "g", "foo bar");
+      expect(r.spans).toEqual([
+        { start: 0, end: 3, matchIndex: 0 },
+        { start: 4, end: 7, matchIndex: 1 },
+      ]);
+    });
+
+    it("full match span matches spans array", () => {
+      const r = computeMatches("\\d+", "g", "x12y34z");
+      for (let i = 0; i < r.matches.length; i++) {
+        expect(r.matches[i].full.start).toBe(r.spans[i].start);
+        expect(r.matches[i].full.end).toBe(r.spans[i].end);
+        expect(r.spans[i].matchIndex).toBe(i);
+      }
+    });
+  });
+
+  describe("capture groups", () => {
+    it("extracts numbered capture groups", () => {
+      const r = computeMatches("(\\d+)-(\\w+)", "g", "123-abc");
+      expect(r.matches).toHaveLength(1);
+      const m = r.matches[0];
+      expect(m.groups).toHaveLength(2);
+      expect(m.groups[0].text).toBe("123");
+      expect(m.groups[0].groupIndex).toBe(1);
+      expect(m.groups[1].text).toBe("abc");
+      expect(m.groups[1].groupIndex).toBe(2);
+    });
+
+    it("handles non-participating groups", () => {
+      // In "a|b", group 2 won't participate when "a" matches
+      const r = computeMatches("(a)|(b)", "g", "a");
+      expect(r.matches).toHaveLength(1);
+      const m = r.matches[0];
+      expect(m.groups).toHaveLength(2);
+      expect(m.groups[0].text).toBe("a");
+      // Group 2 did not participate
+      expect(m.groups[1].text).toBe("");
+      expect(m.groups[1].start).toBe(-1);
+      expect(m.groups[1].end).toBe(-1);
+    });
+
+    it("handles nested groups", () => {
+      const r = computeMatches("((\\d+)-(\\w+))", "g", "42-hi");
+      expect(r.matches).toHaveLength(1);
+      const m = r.matches[0];
+      expect(m.groups[0].text).toBe("42-hi"); // outer group
+      expect(m.groups[1].text).toBe("42"); // inner \d+
+      expect(m.groups[2].text).toBe("hi"); // inner \w+
+    });
+
+    it("extracts groups from multiple matches", () => {
+      const r = computeMatches("(\\d+)", "g", "a1b22c333");
+      expect(r.matches).toHaveLength(3);
+      expect(r.matches[0].groups[0].text).toBe("1");
+      expect(r.matches[1].groups[0].text).toBe("22");
+      expect(r.matches[2].groups[0].text).toBe("333");
+    });
+  });
+
+  describe("named groups", () => {
+    it("populates namedGroups map", () => {
+      const r = computeMatches("(?<year>\\d{4})-(?<month>\\d{2})", "g", "2024-01");
+      expect(r.matches).toHaveLength(1);
+      const m = r.matches[0];
+      expect(m.namedGroups).toBeDefined();
+      expect(m.namedGroups!["year"].text).toBe("2024");
+      expect(m.namedGroups!["month"].text).toBe("01");
+    });
+
+    it("includes named groups in numbered groups too", () => {
+      const r = computeMatches("(?<name>\\w+)", "g", "hello");
+      expect(r.matches[0].groups[0].text).toBe("hello");
+      expect(r.matches[0].namedGroups!["name"].text).toBe("hello");
+    });
+
+    it("handles pattern with no named groups", () => {
+      const r = computeMatches("(\\d+)", "g", "42");
+      expect(r.matches[0].namedGroups).toBeUndefined();
+    });
+  });
+
+  describe("text size cap", () => {
+    it("truncates text beyond MAX_TEXT_LENGTH", () => {
+      const longText = "a".repeat(REGEX_CONFIG.MAX_TEXT_LENGTH + 100);
+      const r = computeMatches("a", "g", longText);
+      // Should only match up to MAX_TEXT_LENGTH
+      expect(r.totalCount).toBe(REGEX_CONFIG.MAX_TEXT_LENGTH);
+      expect(r.truncated).toBe(true);
+    });
+
+    it("does not truncate text within limit", () => {
+      const text = "abc";
+      const r = computeMatches(".", "g", text);
+      expect(r.totalCount).toBe(3);
+      expect(r.truncated).toBe(false);
+    });
+  });
+
+  describe("match count cap", () => {
+    it("caps stored matches at MAX_MATCHES", () => {
+      const text = "a".repeat(REGEX_CONFIG.MAX_MATCHES + 500);
+      const r = computeMatches("a", "g", text);
+      expect(r.matches).toHaveLength(REGEX_CONFIG.MAX_MATCHES);
+      expect(r.spans).toHaveLength(REGEX_CONFIG.MAX_MATCHES);
+      expect(r.totalCount).toBe(REGEX_CONFIG.MAX_MATCHES + 500);
+      expect(r.truncated).toBe(true);
+    });
+
+    it("does not set truncated when under limit", () => {
+      const r = computeMatches("\\d", "g", "123");
+      expect(r.truncated).toBe(false);
+      expect(r.totalCount).toBe(3);
+    });
+  });
+
+  describe("zero-width matches", () => {
+    it("handles zero-width lookahead without infinite loop", () => {
+      const r = computeMatches("(?=a)", "g", "aaa");
+      // Should find positions but not hang
+      expect(r.totalCount).toBeGreaterThan(0);
+      expect(r.error).toBeUndefined();
+    });
+
+    it("handles empty pattern without infinite loop", () => {
+      // Empty string matches everywhere - should terminate
+      const r = computeMatches("(?:)", "g", "ab");
+      expect(r.error).toBeUndefined();
+      expect(r.totalCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns error for invalid regex", () => {
+      const r = computeMatches("[", "g", "test");
+      expect(r.error).toBeDefined();
+      expect(r.matches).toHaveLength(0);
+      expect(r.totalCount).toBe(0);
+    });
+
+    it("does not return error for valid regex with no matches", () => {
+      const r = computeMatches("xyz", "g", "abc");
+      expect(r.error).toBeUndefined();
+    });
+  });
+
+  describe("case-insensitive flag", () => {
+    it("matches case-insensitively with i flag", () => {
+      const r = computeMatches("abc", "gi", "ABC abc Abc");
+      expect(r.totalCount).toBe(3);
+    });
+  });
+
+  describe("multiline flag", () => {
+    it("anchors match per-line with m flag", () => {
+      const r = computeMatches("^\\w+", "gm", "foo\nbar\nbaz");
+      expect(r.totalCount).toBe(3);
+      expect(r.matches.map((m) => m.full.text)).toEqual(["foo", "bar", "baz"]);
+    });
+  });
+});
+
+describe("getMatchColorClass", () => {
+  it("cycles through 6 colors", () => {
+    const classes = new Set<string>();
+    for (let i = 0; i < 6; i++) {
+      classes.add(getMatchColorClass(i));
+    }
+    expect(classes.size).toBe(6);
+  });
+
+  it("wraps around after 6", () => {
+    expect(getMatchColorClass(0)).toBe(getMatchColorClass(6));
+    expect(getMatchColorClass(1)).toBe(getMatchColorClass(7));
+  });
+
+  it("returns active variant when active=true", () => {
+    const base = getMatchColorClass(0);
+    const active = getMatchColorClass(0, true);
+    expect(active).toBe(`${base}-active`);
+  });
+
+  it("returns non-active variant by default", () => {
+    const cls = getMatchColorClass(0);
+    expect(cls).not.toContain("-active");
+  });
+});
+
+describe("computeSingleExecWithLastIndex", () => {
+  it("matches at given lastIndex with sticky flag", () => {
+    const r = computeSingleExecWithLastIndex("\\d+", "gy", "abc123def", 3);
+    expect(r.totalCount).toBe(1);
+    expect(r.matches[0].full.text).toBe("123");
+    expect(r.matches[0].full.start).toBe(3);
+  });
+
+  it("returns empty when no match at lastIndex", () => {
+    const r = computeSingleExecWithLastIndex("\\d+", "gy", "abc123def", 0);
+    expect(r.totalCount).toBe(0);
+    expect(r.matches).toHaveLength(0);
+  });
+
+  it("returns error for invalid pattern", () => {
+    const r = computeSingleExecWithLastIndex("[", "g", "test", 0);
+    expect(r.error).toBe("Invalid pattern");
   });
 });

--- a/src/lib/stores/hoverStore.test.ts
+++ b/src/lib/stores/hoverStore.test.ts
@@ -5,6 +5,7 @@ import {
   setHoveredRange,
   setHoveredStepId,
   setHoveredMatchIndex,
+  setSelectedMatchIndex,
   toggleLockedStep,
   clearAll,
   _reset,
@@ -21,6 +22,7 @@ describe("hoverStore", () => {
       expect(state.hoveredRange).toBeNull();
       expect(state.hoveredStepId).toBeNull();
       expect(state.hoveredMatchIndex).toBeNull();
+      expect(state.selectedMatchIndex).toBeNull();
       expect(state.lockedStepId).toBeNull();
     });
   });
@@ -89,6 +91,40 @@ describe("hoverStore", () => {
     });
   });
 
+  describe("setSelectedMatchIndex", () => {
+    it("updates selectedMatchIndex", () => {
+      setSelectedMatchIndex(1);
+      expect(getSnapshot().selectedMatchIndex).toBe(1);
+    });
+
+    it("can be cleared to null", () => {
+      setSelectedMatchIndex(1);
+      setSelectedMatchIndex(null);
+      expect(getSnapshot().selectedMatchIndex).toBeNull();
+    });
+
+    it("no-ops when setting same value", () => {
+      setSelectedMatchIndex(1);
+      const snapshot1 = getSnapshot();
+      setSelectedMatchIndex(1);
+      expect(getSnapshot()).toBe(snapshot1);
+    });
+
+    it("notifies listeners on change", () => {
+      const listener = vi.fn();
+      subscribe(listener);
+      setSelectedMatchIndex(2);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not notify on no-op", () => {
+      const listener = vi.fn();
+      subscribe(listener);
+      setSelectedMatchIndex(null);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   describe("toggleLockedStep", () => {
     it("sets lockedStepId when null", () => {
       toggleLockedStep("step-1");
@@ -113,6 +149,7 @@ describe("hoverStore", () => {
       setHoveredRange({ start: 0, end: 5 });
       setHoveredStepId("step-1");
       setHoveredMatchIndex(2);
+      setSelectedMatchIndex(3);
       toggleLockedStep("step-3");
 
       clearAll();
@@ -121,6 +158,7 @@ describe("hoverStore", () => {
       expect(state.hoveredRange).toBeNull();
       expect(state.hoveredStepId).toBeNull();
       expect(state.hoveredMatchIndex).toBeNull();
+      expect(state.selectedMatchIndex).toBeNull();
       expect(state.lockedStepId).toBeNull();
     });
 

--- a/src/lib/stores/hoverStore.ts
+++ b/src/lib/stores/hoverStore.ts
@@ -4,6 +4,7 @@ export interface HoverState {
   hoveredRange: Range | null;
   hoveredStepId: string | null;
   hoveredMatchIndex: number | null;
+  selectedMatchIndex: number | null;
   lockedStepId: string | null;
 }
 
@@ -13,6 +14,7 @@ const DEFAULT_STATE: HoverState = {
   hoveredRange: null,
   hoveredStepId: null,
   hoveredMatchIndex: null,
+  selectedMatchIndex: null,
   lockedStepId: null,
 };
 
@@ -62,6 +64,12 @@ export function setHoveredMatchIndex(index: number | null) {
   notify();
 }
 
+export function setSelectedMatchIndex(index: number | null) {
+  if (state.selectedMatchIndex === index) return;
+  state = { ...state, selectedMatchIndex: index };
+  notify();
+}
+
 export function toggleLockedStep(stepId: string) {
   state = {
     ...state,
@@ -75,6 +83,7 @@ export function clearAll() {
     state.hoveredRange === null &&
     state.hoveredStepId === null &&
     state.hoveredMatchIndex === null &&
+    state.selectedMatchIndex === null &&
     state.lockedStepId === null;
   if (isAlreadyDefault) return;
   state = { ...DEFAULT_STATE };


### PR DESCRIPTION
## Summary

- **Added persistent match selection** — new `selectedMatchIndex` in hover store enables click-to-select behavior distinct from transient hover, with toggle-off on re-click
- **Extracted `MatchOverlay` component** — highlight rendering pulled out of `TestTextEditor` into a dedicated component with hover, selection, and color-cycling support
- **Wired selection styling throughout** — `MatchList` items show ring/border styling for selected matches, `MatchOverlay` applies outline classes for selected highlights
- **Added selected highlight CSS classes** — 6 `match-highlight-*-selected` classes with outline + elevated background opacity
- **Comprehensive test coverage** — expanded from 103 to 168 tests across 15 files

### Test breakdown
| Area | File | Tests |
|------|------|-------|
| Match engine (unit) | `lib/regex/match.test.ts` | 33 (was 2) |
| Hover store | `lib/stores/hoverStore.test.ts` | 21 (was 16) |
| useRegexMatches hook | `hooks/__tests__/useRegexMatches.test.tsx` | 7 (new) |
| MatchOverlay component | `components/testbench/__tests__/MatchOverlay.test.tsx` | 13 (new) |
| MatchList component | `components/testbench/__tests__/MatchList.test.tsx` | 14 (new) |
| useHoverSync hook | `hooks/__tests__/useHoverSync.test.tsx` | 9 (was 7) |

### Unit tests cover
- Global and non-global matching, capture group extraction, named groups
- Text size cap (50k), match count cap (1000), zero-width match prevention
- Stale result cancellation, debounce behavior, parseOk guard
- Highlight class application, hover/selection state, mouse/click/keyboard events

## Test plan

- [x] Try `/\d+/g` against `"abc 123 def 456"` — verify 2 highlighted matches
- [x] Click a match in the overlay or match list — confirm distinct outline styling
- [x] Click again to deselect — confirm outline removed
- [x] Try `(?<year>\d{4})-(?<month>\d{2})` against `"2024-01"` — verify named groups in match list
- [x] Enter invalid regex `[` — confirm no crash, no match attempt
- [x] Paste large text (50k+ chars) — confirm truncation notice
- [x] Hover over matches — confirm highlight sync between overlay and match list
- [x] `npm run ci` passes (lint, typecheck, test, build)

Closes #4 