### PR TITLE
test: add regression fixture backbone for v2 quality safeguards

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ const webServerEnv = {
 };
 
 export default defineConfig({
-  testDir: "./e2e",
+  testDir: "./tests/e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -28,6 +28,11 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "iphone-12-smoke",
+      use: { ...devices["iPhone 12"], browserName: "chromium" },
+      grep: /@smoke/,
     },
   ],
   webServer: isCI

--- a/src/components/diff/DiffPanel.tsx
+++ b/src/components/diff/DiffPanel.tsx
@@ -86,6 +86,7 @@ export function DiffPanel({
             value={comparisonPattern}
             onChange={(e) => onComparisonPatternChange(e.target.value)}
             placeholder="Paste the previous regex..."
+            data-testid="comparison-pattern-input"
             className="flex-1 min-w-0 bg-muted/50 border rounded-md px-2 py-1.5 font-mono text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
             spellCheck={false}
             autoComplete="off"
@@ -105,6 +106,8 @@ export function DiffPanel({
                     variant={isActive ? "default" : "outline"}
                     size="sm"
                     onClick={() => toggleComparisonFlag(flag)}
+                    data-testid={`comparison-flag-${flag}`}
+                    data-active={isActive ? "true" : "false"}
                     className={cn(
                       "h-6 w-6 p-0 font-mono text-xs",
                       isActive

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,7 +1,15 @@
 import { test, expect } from "@playwright/test";
 
+function encodeUrlSafe(value: string): string {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
 test.describe("smoke", () => {
-  test("home loads and links to app", async ({ page }) => {
+  test("@smoke home loads and links to app", async ({ page }) => {
     await page.goto("/");
     await expect(
       page.getByRole("heading", {
@@ -14,7 +22,7 @@ test.describe("smoke", () => {
     await expect(page).toHaveURL(/\/app/, { timeout: 20_000 });
   });
 
-  test("app workspace shows pattern panel and Monaco editor", async ({ page }) => {
+  test("@smoke app workspace shows pattern panel and Monaco editor", async ({ page }) => {
     await page.goto("/app");
     await expect(
       page.getByRole("heading", { name: "Pattern", exact: true })
@@ -31,18 +39,13 @@ test.describe("workspace integration", () => {
   test("typing regex updates explanation panel", async ({ page }) => {
     await page.goto("/app");
 
-    // Wait for Monaco editor to load
     const editor = page.locator(".monaco-editor").first();
     await expect(editor).toBeVisible({ timeout: 30_000 });
 
-    // Type a regex pattern into the Monaco editor
     await editor.click();
     await page.keyboard.type("\\d+");
 
-    // Explanation panel should update with content about digits
-    await expect(
-      page.getByText(/one or more/i)
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/one or more/i)).toBeVisible({ timeout: 10_000 });
   });
 
   test("switching analysis tabs preserves workspace state", async ({ page }) => {
@@ -51,88 +54,135 @@ test.describe("workspace integration", () => {
     const editor = page.locator(".monaco-editor").first();
     await expect(editor).toBeVisible({ timeout: 30_000 });
 
-    // Type a pattern
     await editor.click();
     await page.keyboard.type("abc");
 
-    // Open the "More" dropdown and click Structure
     await page.getByRole("button", { name: /More tabs/i }).click();
     await page.getByRole("menuitem", { name: /Structure/i }).click();
     await expect(page.getByText(/Pattern structure/i)).toBeVisible({
       timeout: 5_000,
     });
 
-    // Click back to Explanation tab
     await page.getByRole("tab", { name: /Explain|Exp/i }).click();
 
-    // Pattern should still be present - explanation content should still exist
-    await expect(
-      page.getByText(/what this pattern does/i)
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/what this pattern does/i)).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
-  test("invalid regex shows guided fallback in panels", async ({ page }) => {
+  test("warning card click toggles lock state", async ({ page }) => {
     await page.goto("/app");
 
     const editor = page.locator(".monaco-editor").first();
     await expect(editor).toBeVisible({ timeout: 30_000 });
 
-    // Type an invalid regex
+    await editor.click();
+    await page.keyboard.type("example.com");
+
+    await page.getByRole("tab", { name: /Warnings|Warn/i }).click();
+    const warningCard = page.getByRole("button", { name: /Unescaped dot/i });
+
+    await expect(warningCard).toHaveAttribute("aria-pressed", "false");
+    await warningCard.click();
+    await expect(warningCard).toHaveAttribute("aria-pressed", "true");
+    await warningCard.click();
+    await expect(warningCard).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("invalid regex remains resilient across warnings, failure, and diff tabs", async ({ page }) => {
+    await page.goto("/app");
+
+    const editor = page.locator(".monaco-editor").first();
+    await expect(editor).toBeVisible({ timeout: 30_000 });
+
     await editor.click();
     await page.keyboard.type("[");
+    await page.getByRole("textbox", { name: /Paste sample text/i }).fill("abc");
 
-    // Explanation panel should show an error state
-    await expect(
-      page.getByText(/fix the pattern/i)
-    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("tab", { name: /Warnings|Warn/i }).click();
+    await expect(page.getByText(/fix the pattern to run safety checks/i)).toBeVisible({
+      timeout: 10_000,
+    });
 
-    // Open the "More" dropdown and switch to Structure tab - should also show fallback
+    await page.getByRole("tab", { name: /Failure|Fail/i }).click();
+    await expect(page.getByText(/no failure data/i)).toBeVisible({ timeout: 10_000 });
+
     await page.getByRole("button", { name: /More tabs/i }).click();
-    await page.getByRole("menuitem", { name: /Structure/i }).click();
+    await page.getByRole("menuitem", { name: /Diff/i }).click();
+    await page.getByLabel(/Compare against/i).fill("abc");
+
     await expect(
-      page.getByText(/invalid pattern/i)
-    ).toBeVisible({ timeout: 5_000 });
+      page.getByText(/Structural diff unavailable — one or both patterns could not be parsed/i)
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByText(/Explanation diff unavailable — one or both patterns could not be parsed/i)
+    ).toBeVisible({ timeout: 10_000 });
   });
 });
 
 test.describe("URL state sharing", () => {
-  test("shared URL with encoded state restores pattern and text", async ({ page }) => {
-    // Encode a known pattern and text as URL params
-    const pattern = btoa(encodeURIComponent("\\d+"));
-    const text = btoa(encodeURIComponent("abc 123 def"));
+  test("@smoke shared URL with encoded state restores pattern, text, and comparison state", async ({ page }) => {
+    const pattern = encodeUrlSafe("\\d+");
+    const text = encodeUrlSafe("abc 123 def");
+    const comparisonPattern = encodeUrlSafe("\\w+");
     const flags = "gi";
+    const comparisonFlags = "m";
 
-    await page.goto(`/app?p=${pattern}&f=${flags}&t=${text}`);
+    await page.goto(
+      `/app?p=${pattern}&f=${flags}&t=${text}&cp=${comparisonPattern}&cf=${comparisonFlags}`
+    );
 
-    // Wait for workspace to load
     await expect(
       page.getByRole("heading", { name: "Pattern", exact: true })
     ).toBeVisible({ timeout: 20_000 });
 
-    // The test text should appear in the textarea
     await expect(
       page.getByRole("textbox", { name: /Paste sample text/i })
     ).toHaveValue("abc 123 def", { timeout: 10_000 });
 
-    // Explanation panel should update based on the restored pattern
-    await expect(
-      page.getByText(/one or more/i)
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/one or more/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: /More tabs/i }).click();
+    await page.getByRole("menuitem", { name: /Diff/i }).click();
+
+    await expect(page.getByLabel(/Compare against/i)).toHaveValue("\\w+");
+    await expect(page.getByTestId("comparison-flag-m")).toHaveAttribute("data-active", "true");
   });
 
   test("invalid URL params do not crash the app", async ({ page }) => {
-    // Navigate with malformed base64 in params
     await page.goto("/app?p=!!!invalid-base64!!!&f=xyz&t=also-broken");
 
-    // App should still load without crashing
     await expect(
       page.getByRole("heading", { name: "Pattern", exact: true })
     ).toBeVisible({ timeout: 20_000 });
 
-    // Monaco editor should be visible (app not broken)
     await expect(page.locator(".monaco-editor").first()).toBeVisible({
       timeout: 30_000,
     });
+  });
+});
+
+test.describe("diff review", () => {
+  test("diff tab renders behavior summary for pattern changes", async ({ page }) => {
+    await page.goto("/app");
+
+    const editor = page.locator(".monaco-editor").first();
+    await expect(editor).toBeVisible({ timeout: 30_000 });
+
+    await editor.click();
+    await page.keyboard.type("foo");
+
+    await page.getByRole("button", { name: /More tabs/i }).click();
+    await page.getByRole("menuitem", { name: /Diff/i }).click();
+
+    await page.getByLabel(/Compare against/i).fill("f.o");
+
+    await expect(page.getByRole("heading", { name: /Review Summary/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByText(/Wildcard removed — matching is more specific|Literal replaced with wildcard/i)
+    ).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -140,28 +190,22 @@ test.describe("template library", () => {
   test("selecting a template updates workspace", async ({ page }) => {
     await page.goto("/app");
 
-    // Wait for workspace to load
     await expect(page.locator(".monaco-editor").first()).toBeVisible({
       timeout: 30_000,
     });
 
-    // Open template library dialog
     await page.getByRole("button", { name: /Examples/i }).first().click();
 
-    // Dialog should appear with example patterns title
     await expect(
       page.getByRole("heading", { name: /Example Patterns/i })
     ).toBeVisible({ timeout: 5_000 });
 
-    // Click the "Basic email" template
     await page.getByText("Basic email").first().click();
 
-    // Dialog should close and workspace should update
     await expect(
       page.getByRole("heading", { name: /Example Patterns/i })
     ).not.toBeVisible({ timeout: 5_000 });
 
-    // Test text from the email template should be visible
     await expect(page.getByText("test@example.com")).toBeVisible({
       timeout: 10_000,
     });
@@ -174,24 +218,19 @@ test.describe("template library", () => {
       timeout: 30_000,
     });
 
-    // Open template library
     await page.getByRole("button", { name: /Examples/i }).first().click();
     await expect(
       page.getByRole("heading", { name: /Example Patterns/i })
     ).toBeVisible({ timeout: 5_000 });
 
-    // Search for "email"
     const searchInput = page.getByPlaceholder("Search patterns...");
     await searchInput.fill("email");
 
-    // Should see email-related templates
     await expect(page.getByText("Basic email")).toBeVisible({ timeout: 3_000 });
     await expect(page.getByText("Brutal email validator")).toBeVisible({
       timeout: 3_000,
     });
 
-    // Non-email templates should not be visible
     await expect(page.getByText("US phone number")).not.toBeVisible();
   });
 });
-

--- a/tests/fixtures/regression/diff.fixture.ts
+++ b/tests/fixtures/regression/diff.fixture.ts
@@ -1,0 +1,20 @@
+import type { DiffRegressionFixture } from "./types";
+
+export const diffRegressionFixtures: DiffRegressionFixture[] = [
+  {
+    name: "case-insensitive broadening",
+    oldPattern: "abc",
+    oldFlags: "",
+    newPattern: "abc",
+    newFlags: "i",
+    expectedSummaryIncludes: ["Case sensitivity disabled"],
+  },
+  {
+    name: "literal to wildcard change",
+    oldPattern: "foo",
+    oldFlags: "",
+    newPattern: "f.o",
+    newFlags: "",
+    expectedSummaryIncludes: ["Wildcard added"],
+  },
+];

--- a/tests/fixtures/regression/explanation.fixture.ts
+++ b/tests/fixtures/regression/explanation.fixture.ts
@@ -1,0 +1,18 @@
+import type { ExplanationRegressionFixture } from "./types";
+
+export const explanationRegressionFixtures: ExplanationRegressionFixture[] = [
+  {
+    name: "digits with quantifier",
+    pattern: "\\d+",
+    flags: "g",
+    mode: "simple",
+    expectedLabels: ["digit", "one or more"],
+  },
+  {
+    name: "anchored technical breakdown",
+    pattern: "^[A-Z]{2}\\d{3}$",
+    flags: "",
+    mode: "technical",
+    expectedLabels: ["start of input", "class [a-z]", "exactly", "end of input"],
+  },
+];

--- a/tests/fixtures/regression/failure.fixture.ts
+++ b/tests/fixtures/regression/failure.fixture.ts
@@ -1,0 +1,18 @@
+import type { FailureRegressionFixture } from "./types";
+
+export const failureRegressionFixtures: FailureRegressionFixture[] = [
+  {
+    name: "start anchor fails on leading text",
+    pattern: "^abc$",
+    flags: "",
+    text: "xabc",
+    expectedReasonIncludes: "expected the character",
+  },
+  {
+    name: "digit escape fails on alpha",
+    pattern: "\\d+",
+    flags: "",
+    text: "abc",
+    expectedReasonIncludes: "Expected",
+  },
+];

--- a/tests/fixtures/regression/types.ts
+++ b/tests/fixtures/regression/types.ts
@@ -1,0 +1,40 @@
+import type { ExplanationMode, RegexState } from "@/types";
+
+export interface ExplanationRegressionFixture {
+  name: string;
+  pattern: string;
+  flags: string;
+  mode: ExplanationMode;
+  expectedLabels: string[];
+}
+
+export interface WarningsRegressionFixture {
+  name: string;
+  pattern: string;
+  flags: string;
+  text: string;
+  expectedWarningIds: string[];
+}
+
+export interface FailureRegressionFixture {
+  name: string;
+  pattern: string;
+  flags: string;
+  text: string;
+  expectedReasonIncludes: string;
+}
+
+export interface DiffRegressionFixture {
+  name: string;
+  oldPattern: string;
+  oldFlags: string;
+  newPattern: string;
+  newFlags: string;
+  expectedSummaryIncludes: string[];
+}
+
+export interface UrlRestoreRegressionFixture {
+  name: string;
+  state: RegexState;
+  expectedDecoded: Partial<RegexState>;
+}

--- a/tests/fixtures/regression/url-restore.fixture.ts
+++ b/tests/fixtures/regression/url-restore.fixture.ts
@@ -1,0 +1,26 @@
+import type { UrlRestoreRegressionFixture } from "./types";
+
+export const urlRestoreRegressionFixtures: UrlRestoreRegressionFixture[] = [
+  {
+    name: "round-trip preserves comparison state",
+    state: {
+      pattern: "\\d+",
+      flags: "gi",
+      text: "abc 123",
+      flavor: "javascript",
+      comparisonPattern: "\\w+",
+      comparisonFlags: "m",
+      explanationMode: "technical",
+      selectedTemplate: "basic-email",
+    },
+    expectedDecoded: {
+      pattern: "\\d+",
+      flags: "gi",
+      text: "abc 123",
+      comparisonPattern: "\\w+",
+      comparisonFlags: "m",
+      explanationMode: "technical",
+      selectedTemplate: "basic-email",
+    },
+  },
+];

--- a/tests/fixtures/regression/warnings.fixture.ts
+++ b/tests/fixtures/regression/warnings.fixture.ts
@@ -1,0 +1,18 @@
+import type { WarningsRegressionFixture } from "./types";
+
+export const warningsRegressionFixtures: WarningsRegressionFixture[] = [
+  {
+    name: "nested quantifier risk",
+    pattern: "(a+)+",
+    flags: "",
+    text: "aaaaaaaaaaaaaaaaaaaaX",
+    expectedWarningIds: ["nested-quantifiers"],
+  },
+  {
+    name: "unescaped literal dot risk",
+    pattern: "example.com",
+    flags: "",
+    text: "exampleXcom",
+    expectedWarningIds: ["unescaped-dot"],
+  },
+];

--- a/tests/unit/regression/pure-lib-regression.test.ts
+++ b/tests/unit/regression/pure-lib-regression.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { parseRegex } from "@/lib/regex/parse";
+import { computeMatches } from "@/lib/regex/match";
+import { generateExplanation } from "@/lib/explain/explain";
+import { analyzeWarnings } from "@/lib/warnings/heuristics";
+import { analyzeFailure } from "@/lib/failure/analyzeFailure";
+import {
+  computeSyntaxDiff,
+  computeFlagDiff,
+  computeStructuralDiff,
+  computeExplanationDiff,
+  computeWarningDiff,
+  synthesizeBehaviorSummary,
+} from "@/lib/diff";
+import { decodeState, encodeState } from "@/lib/regex/serialize";
+import { explanationRegressionFixtures } from "../../fixtures/regression/explanation.fixture";
+import { warningsRegressionFixtures } from "../../fixtures/regression/warnings.fixture";
+import { failureRegressionFixtures } from "../../fixtures/regression/failure.fixture";
+import { diffRegressionFixtures } from "../../fixtures/regression/diff.fixture";
+import { urlRestoreRegressionFixtures } from "../../fixtures/regression/url-restore.fixture";
+
+describe("regression fixtures (pure libs)", () => {
+  it("explanation fixtures remain stable", () => {
+    for (const fixture of explanationRegressionFixtures) {
+      const parseResult = parseRegex(fixture.pattern, fixture.flags);
+      expect(parseResult.ok, fixture.name).toBe(true);
+      if (!parseResult.ok) continue;
+
+      const explanation = generateExplanation(parseResult, fixture.mode);
+      expect(explanation.steps.length, fixture.name).toBeGreaterThan(0);
+
+      const labels = explanation.steps.map((step) => step.label.toLowerCase()).join(" ");
+      for (const expected of fixture.expectedLabels) {
+        expect(labels, fixture.name).toContain(expected.toLowerCase());
+      }
+    }
+  });
+
+  it("warning fixtures remain stable", () => {
+    for (const fixture of warningsRegressionFixtures) {
+      const parseResult = parseRegex(fixture.pattern, fixture.flags);
+      const matchResult = computeMatches(fixture.pattern, fixture.flags, fixture.text);
+      const warnings = analyzeWarnings(
+        fixture.pattern,
+        fixture.flags,
+        parseResult,
+        matchResult,
+      );
+
+      const warningIds = warnings.warnings.map((warning) => warning.id);
+      for (const id of fixture.expectedWarningIds) {
+        expect(warningIds, fixture.name).toContain(id);
+      }
+    }
+  });
+
+  it("failure fixtures remain stable", () => {
+    for (const fixture of failureRegressionFixtures) {
+      const parseResult = parseRegex(fixture.pattern, fixture.flags);
+      const matchResult = computeMatches(fixture.pattern, fixture.flags, fixture.text);
+      const failure = analyzeFailure(
+        fixture.pattern,
+        fixture.flags,
+        fixture.text,
+        parseResult,
+        matchResult,
+      );
+
+      expect(failure.didMatch, fixture.name).toBe(false);
+      if (failure.didMatch) continue;
+
+      expect(failure.reason.toLowerCase(), fixture.name).toContain(
+        fixture.expectedReasonIncludes.toLowerCase(),
+      );
+    }
+  });
+
+  it("diff fixtures remain stable", () => {
+    for (const fixture of diffRegressionFixtures) {
+      const oldParse = parseRegex(fixture.oldPattern, fixture.oldFlags);
+      const newParse = parseRegex(fixture.newPattern, fixture.newFlags);
+      expect(newParse.ok, fixture.name).toBe(true);
+      if (!newParse.ok) continue;
+
+      const oldExplanation = oldParse.ok ? generateExplanation(oldParse) : { steps: [] };
+      const newExplanation = generateExplanation(newParse);
+
+      const oldWarnings = analyzeWarnings(
+        fixture.oldPattern,
+        fixture.oldFlags,
+        oldParse,
+        computeMatches(fixture.oldPattern, fixture.oldFlags, ""),
+      );
+      const newWarnings = analyzeWarnings(
+        fixture.newPattern,
+        fixture.newFlags,
+        newParse,
+        computeMatches(fixture.newPattern, fixture.newFlags, ""),
+      );
+
+      const diff = {
+        syntax: computeSyntaxDiff(fixture.oldPattern, fixture.newPattern),
+        flags: computeFlagDiff(fixture.oldFlags, fixture.newFlags),
+        structural:
+          oldParse.ok && newParse.ok
+            ? computeStructuralDiff(oldParse.normalized, newParse.normalized)
+            : null,
+        explanation: computeExplanationDiff(oldExplanation.steps, newExplanation.steps),
+        warnings: computeWarningDiff(oldWarnings.warnings, newWarnings.warnings),
+        behaviorSummary: { summaries: [], hasSummaries: false },
+      };
+
+      const summary = synthesizeBehaviorSummary(diff);
+      expect(summary.hasSummaries, fixture.name).toBe(true);
+
+      const allMessages = summary.summaries.map((item) => item.message).join(" ");
+      for (const snippet of fixture.expectedSummaryIncludes) {
+        expect(allMessages, fixture.name).toContain(snippet);
+      }
+    }
+  });
+
+  it("url restore fixtures round-trip comparison fields", () => {
+    for (const fixture of urlRestoreRegressionFixtures) {
+      const encoded = encodeState(fixture.state);
+      const decoded = decodeState(encoded);
+
+      expect(decoded, fixture.name).toMatchObject(fixture.expectedDecoded);
+      expect(decoded.comparisonPattern, fixture.name).toBe(
+        fixture.expectedDecoded.comparisonPattern,
+      );
+      expect(decoded.comparisonFlags, fixture.name).toBe(
+        fixture.expectedDecoded.comparisonFlags,
+      );
+    }
+  });
+
+  it("url restore sanitizes invalid flags", () => {
+    const decoded = decodeState({ f: "giz!", cf: "my?" });
+    expect(decoded.flags).toBe("gi");
+    expect(decoded.comparisonFlags).toBe("my");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "tests/unit/**/*.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
### Summary
- Add a dedicated regression fixture library under `tests/fixtures/regression` for explanation, warnings, failure analysis, diff behavior summaries, and URL restore scenarios.
- Add fixture-driven pure-logic regression coverage in `tests/unit/regression/pure-lib-regression.test.ts` to detect deterministic output drift.
- Migrate and expand Playwright coverage to `tests/e2e/app.spec.ts`, including diff summaries, warning interaction state, URL restore with comparison params, invalid-regex resilience, and a mobile smoke subset.

#### Why
RegexLens depends on deterministic explanation and diff quality. This introduces a stable regression backbone so future improvements can ship safely without breaking trust-critical behavior.

### What changed
- Fixtures: `tests/fixtures/regression/*`
- Unit regression tests: `tests/unit/regression/pure-lib-regression.test.ts`
- E2E migration + expansion: `tests/e2e/app.spec.ts` (from `e2e/app.spec.ts`)
- Config updates: `vitest.config.ts`, `playwright.config.ts`
- Selector hardening for diff controls: `src/components/diff/DiffPanel.tsx` (non-visual `data-testid/state` attrs)

### Validation
- [X] `npm run lint 
- [X] `npm run typecheck`
- [X] `npm test`
- [X] `npm run test:e2e` 

### Notes
- Existing colocated tests in `src/**/*.test.ts(x)` were preserved.
- Runtime fixture loader in `data/fixtures/regexlens-fixture-v1.json` remains unchanged.